### PR TITLE
fix: make kv_scope optional for secret retrieval when identity is not required

### DIFF
--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -96,7 +96,6 @@ module "ca" {
   source  = "cloudnationhq/ca/azure"
   version = "~> 0.1"
 
-
   naming = local.naming
 
   environment = {
@@ -160,8 +159,9 @@ module "ca" {
         }
 
         registry = {
-          server = module.acr.acr.login_server
-          scope  = module.acr.acr.id
+          server   = module.acr.acr.login_server
+          username = module.acr.acr.admin_username
+          password = module.acr.acr.admin_password
         }
       }
 
@@ -219,7 +219,6 @@ module "ca" {
       app3 = {
         revision_mode         = "Single"
         workload_profile_name = "Consumption"
-        kv_scope              = module.kv.vault.id
         template = {
           min_replicas    = 1
           max_replicas    = 3
@@ -289,8 +288,11 @@ module "ca" {
                 DEBUG = {
                   value = "True"
                 }
-                SECRET_KEY = {
-                  secret_name = "secret-key"
+                SECRET_KEY1 = {
+                  secret_name = "secret-key1"
+                }
+                SECRET_KEY2 = {
+                  secret_name = "secret-key2"
                 }
               }
             }
@@ -298,12 +300,16 @@ module "ca" {
         }
 
         secrets = {
-          secret-key = {
+          secret-key1 = {
             key_vault_secret_id = module.kv.secrets.secret1.versionless_id
             kv_scope            = module.kv.vault.id
             identity = {
               name = "uai-secret-with-override-name"
             }
+          }
+          secret-key2 = {
+            key_vault_secret_id = module.kv.secrets.secret1.versionless_id
+            kv_scope            = module.kv.vault.id
           }
         }
 


### PR DESCRIPTION
## Description

- Fix: Made kv_scope optional when identity is not required for the secret retrieval, when the secret value is used instead of the key_vault_secret_id. 
- Fix to bring your own user assigned identity, by specifying the name and existing property instead of the id, and will lookup the id by the use of a new data block. Previously, the id was used to pass on from the configuration, and this id was used as a key for the role_assignment, however Terraform could not determine the full keys of the user_assigned_identity resource. 

## PR Checklist

- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules


<!-- You can erase any parts of this template below this point that are not applicable to your Pull Request. -->


## Changes to existing Resource / Data Source

- [x] I have added an explanation of what my changes do and why I'd like you to include them (This may be covered by linking to an issue above, but may benefit from additional explanation).
- [x] I have successfully run tests with my changes locally. If not, please provide details on testing challenges that prevented you running the tests.

## Change Log

Below please provide what should go into the changelog (if anything) 

<!-- Replace the changelog example below with your entry. One resource per line. -->

 * `resource.azurerm_container_app` - fix secrets to handle secret value without use of identity and kv_scope, updated identities, registry and secrets block, to handle user_assigned_identities that are already pre-existing (bring your own). 
 * `resource.azurerm_role_assignment` - updated to handle for byo user_assigned_identities
 * `resource.azurerm_user_assigned_identity` - updated to handle for byo user_assigned_identities
 * `data.azurerm_user_assigned_identity` - newly added to lookup a bring your own (pre-existing) user_assigned_identity

<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [ ] Breaking change (not backwards compatible with previous releases)


## Related Issue(s)
Fixes #12 
