### PR TITLE
fix: add dependson on container app jobs regarding acr pull role assignments

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -594,6 +594,10 @@ resource "azurerm_container_app_job" "job" {
   }
 
   tags = try(each.value.tags, var.tags)
+
+  depends_on = [
+    azurerm_role_assignment.role_acr_pull_jobs
+  ]
 }
 
 resource "azurerm_user_assigned_identity" "identity_jobs" {


### PR DESCRIPTION
## Description

This PR adds a depends_on on the container app job regarding the acr pull role assignment. The container app is started first without the role assignment being set as shown below

```
module.ca.azurerm_container_app_job.job["job1"]: Creating...
module.ca.azurerm_role_assignment.role_acr_pull_jobs["uai-runners-dev-job1"]: Creating...
module.ca.azurerm_role_assignment.role_acr_pull_jobs["uai-runners-dev-job1"]: Still creating... [10s elapsed]
module.ca.azurerm_role_assignment.role_acr_pull_jobs["uai-runners-dev-job1"]: Still creating... [20s elapsed]
module.ca.azurerm_role_assignment.role_acr_pull_jobs["uai-runners-dev-job1"]: Creation complete after 27s [id=/subscriptions/0e188f4f-c82f-4920-aef9-2fd38c6dda7a/resourceGroups/rg-runners-dev/providers/Microsoft.ContainerRegistry/registries/acrrunnersdevqjln/providers/Microsoft.Authorization/roleAssignments/589e3e18-75e8-fecd-17e5-cfb58bed4521]
╷
│ Error: creating Job (Subscription: "0e188f4f-c82f-4920-aef9-2fd38c6dda7a"
│ Resource Group Name: "rg-runners-dev"
│ Job Name: "caj-runners-dev-job1"): performing CreateOrUpdate: unexpected status 400 (400 Bad Request) with error: InvalidParameterValueInContainerTemplate: The following field(s) are either invalid or missing. Field 'template.containers.runners.image' is invalid with details: 'Invalid value: "acrrunnersdevqjln.azurecr.io/runners:build-202408011532": unable to pull image using Managed identity /subscriptions/0e188f4f-c82f-4920-aef9-2fd38c6dda7a/resourceGroups/rg-runners-dev/providers/Microsoft.ManagedIdentity/userAssignedIdentities/uai-runners-dev-job1 for registry acrrunnersdevqjln.azurecr.io';.
│ 
│   with module.ca.azurerm_container_app_job.job["job1"],
│   on .terraform/modules/ca/main.tf line 357, in resource "azurerm_container_app_job" "job":
│  357: resource "azurerm_container_app_job" "job" {
│ 

```
## PR Checklist

- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

<!-- What type of PR is this? -->
This is a (please select all that apply):

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking change (not backwards compatible with previous releases)