### PR TITLE
feat!: support multiple authentication blocks in jobs

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -1,0 +1,13 @@
+## Testing
+
+Ensure Go and Terraform are installed.
+
+Run tests for different scenarios by setting the example flag when running the tests.
+
+To run a test, use make test example=default, replacing default with the example you want to test from the examples directory.
+
+Add skip-destroy=true to skip the destroy step, like make test example=default skip-destroy=true.
+
+For running all tests in parallel or sequentially with make test-parallel or make test-sequential, exclude specific examples by adding exception=example1,example2, where example1 and example2 are examples to skip.
+
+These tests ensure the module's reliability across configurations.

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -99,7 +99,7 @@ module "acr" {
 
 module "ca" {
   source  = "cloudnationhq/ca/azure"
-  version = "~> 2.0"
+  version = "~> 3.0"
 
   naming = local.naming
 

--- a/examples/default/main.tf
+++ b/examples/default/main.tf
@@ -19,7 +19,7 @@ module "rg" {
 
 module "ca" {
   source  = "cloudnationhq/ca/azure"
-  version = "~> 2.0"
+  version = "~> 3.0"
 
   naming = local.naming
 

--- a/examples/identities/main.tf
+++ b/examples/identities/main.tf
@@ -61,7 +61,7 @@ module "acr" {
 
 module "ca" {
   source  = "cloudnationhq/ca/azure"
-  version = "~> 2.0"
+  version = "~> 3.0"
 
   naming = local.naming
 

--- a/examples/jobs/jobs.tf
+++ b/examples/jobs/jobs.tf
@@ -28,8 +28,10 @@ locals {
               targetWorkflowQueueLength = "1"
             }
             authentication = {
-              secret_name       = "personal-access-token"
-              trigger_parameter = "personalAccessToken"
+              auth1 = {
+                secret_name       = "personal-access-token"
+                trigger_parameter = "personalAccessToken"
+              }
             }
           }
         }
@@ -115,8 +117,14 @@ locals {
               targetWorkflowQueueLength = "1"
             }
             authentication = {
-              secret_name       = "personal-access-token"
-              trigger_parameter = "personalAccessToken"
+              auth1 = {
+                secret_name       = "personal-access-token"
+                trigger_parameter = "personalAccessToken"
+              }
+              auth2 = {
+                secret_name       = "secret-key"
+                trigger_parameter = "superSecretTrigger"
+              }
             }
           }
         }

--- a/examples/jobs/main.tf
+++ b/examples/jobs/main.tf
@@ -2,7 +2,7 @@ module "naming" {
   source  = "cloudnationhq/naming/azure"
   version = "~> 0.1"
 
-  suffix = ["demo", "dev"]
+  suffix = ["demo", "dev", "jp"]
 }
 
 module "rg" {
@@ -55,7 +55,7 @@ module "acr" {
 
 module "ca" {
   source  = "cloudnationhq/ca/azure"
-  version = "~> 2.0"
+  version = "~> 3.0"
 
   naming = local.naming
 

--- a/examples/jobs/main.tf
+++ b/examples/jobs/main.tf
@@ -2,7 +2,7 @@ module "naming" {
   source  = "cloudnationhq/naming/azure"
   version = "~> 0.1"
 
-  suffix = ["demo", "dev", "jp"]
+  suffix = ["demo", "dev"]
 }
 
 module "rg" {

--- a/main.tf
+++ b/main.tf
@@ -572,7 +572,7 @@ resource "azurerm_container_app_job" "job" {
               metadata         = try(rules.value.metadata, {})
 
               dynamic "authentication" {
-                for_each = try(rules.value.authentication, null) != null ? { default = rules.value.authentication } : {}
+                for_each = { for key, auth in lookup(rules.value, "authentication", {}) : key => auth }
                 content {
                   trigger_parameter = authentication.value.trigger_parameter
                   secret_name       = authentication.value.secret_name


### PR DESCRIPTION
## Description

Breaking!!: In Container App Jobs we can have multiple authentication blocks. This change implements this. If this is being use, please update it according to the following example:

From:
```
authentication = {
  secret_name       = "personal-access-token"
  trigger_parameter = "personalAccessToken"
}
```
To:
```
authentication = {
  auth1 = {
    secret_name       = "personal-access-token"
    trigger_parameter = "personalAccessToken"
  }
}
```

## PR Checklist

- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules

## Change Log

Breaking!!: In Container App Jobs we can have multiple authentication blocks. This change implements this. If this is being use, please update it according to the following example:

From:
```
authentication = {
  secret_name       = "personal-access-token"
  trigger_parameter = "personalAccessToken"
}
```
To:
```
authentication = {
  auth1 = {
    secret_name       = "personal-access-token"
    trigger_parameter = "personalAccessToken"
  }
}
```

<!-- What type of PR is this? -->
This is a (please select all that apply):

- [ ] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [x] Enhancement
- [x] Breaking change (not backwards compatible with previous releases)

## Related Issue(s)
Fixes #45
