### PR TITLE
feat: add identity_id to container app and job custom scale rule blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,7 @@ object({
           name             = string
           custom_rule_type = string
           metadata         = map(string)
+          identity_id      = optional(string)
           authentication = optional(map(object({
             secret_name       = string
             trigger_parameter = string
@@ -418,6 +419,7 @@ object({
             name             = optional(string)
             custom_rule_type = optional(string)
             metadata         = optional(map(string), {})
+            identity_id      = optional(string)
             authentication = optional(map(object({
               trigger_parameter = string
               secret_name       = string

--- a/main.tf
+++ b/main.tf
@@ -218,6 +218,7 @@ resource "azurerm_container_app" "ca" {
         name             = custom_scale_rule.value.name
         custom_rule_type = custom_scale_rule.value.custom_rule_type
         metadata         = custom_scale_rule.value.metadata
+        identity_id      = custom_scale_rule.value.identity_id
 
         dynamic "authentication" {
           for_each = custom_scale_rule.value.authentication != null ? custom_scale_rule.value.authentication : {}
@@ -658,6 +659,7 @@ resource "azurerm_container_app_job" "job" {
               name             = rules.value.name
               custom_rule_type = rules.value.custom_rule_type
               metadata         = rules.value.metadata
+              identity_id      = rules.value.identity_id
 
               dynamic "authentication" {
                 for_each = rules.value.authentication != null ? rules.value.authentication : {}

--- a/variables.tf
+++ b/variables.tf
@@ -130,6 +130,7 @@ variable "environment" {
           name             = string
           custom_rule_type = string
           metadata         = map(string)
+          identity_id      = optional(string)
           authentication = optional(map(object({
             secret_name       = string
             trigger_parameter = string
@@ -357,6 +358,7 @@ variable "environment" {
             name             = optional(string)
             custom_rule_type = optional(string)
             metadata         = optional(map(string), {})
+            identity_id      = optional(string)
             authentication = optional(map(object({
               trigger_parameter = string
               secret_name       = string


### PR DESCRIPTION
Expose the optional identity_id provider attribute on the
azurerm_container_app template.custom_scale_rule block and the
azurerm_container_app_job event_trigger_config.scale.rules block so scale
rules can authenticate via a System or User Assigned Managed Identity.

Fixes #101 and #108
